### PR TITLE
Firewall rule numberings

### DIFF
--- a/manifests/profile/firewall/post.pp
+++ b/manifests/profile/firewall/post.pp
@@ -1,18 +1,18 @@
 # post-firewall rules to reject remaining traffic
 class openstack::profile::firewall::post {
-  firewall { '8999 - Accept all management network traffic':
+  firewall { '8599 - Accept all management network traffic':
     proto  => 'all',
     state  => ['NEW'],
     action => 'accept',
     source => $::openstack::config::network_management,
   } ->
-  firewall { '9100 - Accept all vm network traffic':
+  firewall { '8799 - Accept all vm network traffic':
     proto  => 'all',
     state  => ['NEW'],
     action => 'accept',
     source => $::openstack::config::network_data,
   } ->
-  firewall { '9999 - Reject remaining traffic':
+  firewall { '8999 - Reject remaining traffic':
     proto  => 'all',
     action => 'reject',
     reject => 'icmp-host-prohibited',

--- a/manifests/profile/firewall/pre.pp
+++ b/manifests/profile/firewall/pre.pp
@@ -32,6 +32,6 @@ class openstack::profile::firewall::pre {
     state  => ['NEW', 'ESTABLISHED', 'RELATED'],
     action => 'accept',
     dport   => 22,
-    before => [ Firewall['8999 - Accept all management network traffic'] ],
+    before => [ Firewall['8599 - Accept all management network traffic'] ],
   }
 }

--- a/manifests/resources/firewall.pp
+++ b/manifests/resources/firewall.pp
@@ -6,7 +6,7 @@ define openstack::resources::firewall ( $port ) {
       state  => ['NEW'],
       action => 'accept',
       dport   => $port,
-      before => Firewall['8999 - Accept all management network traffic'],
+      before => Firewall['8599 - Accept all management network traffic'],
     }
   } else {
     firewall { "${port} - ${title}":
@@ -14,7 +14,7 @@ define openstack::resources::firewall ( $port ) {
       state  => ['NEW'],
       action => 'accept',
       dport   => $port,
-      before => Firewall['8999 - Accept all management network traffic'],
+      before => Firewall['8599 - Accept all management network traffic'],
     }
   }
 }


### PR DESCRIPTION
Firewall rules are not allowed to start with a 9 for some reason